### PR TITLE
chore/fix: upgrade Node 22 LTS + explicit OG image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
       - run: npm ci
       - run: npm run lint
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - run: npm ci

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.61.0"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "allowScripts": {
     "esbuild@0.25.12": true,
     "esbuild@0.27.7": true,

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -35,8 +35,11 @@ const ogImage = 'https://devenney.io/assets/images/logo_sm.png';
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={ogImage} />
+    <meta property="og:image:secure_url" content={ogImage} />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Brendan Devenney — Staff Software Engineer" />
     <meta property="og:url" content={canonical} />
 
     <!-- Favicon -->


### PR DESCRIPTION
## Summary

**Node.js 22 LTS upgrade**
- Bumps `node-version` from 20 to 22 in both GHA jobs (`lint` and `build-and-audit`)
- Adds `engines: { "node": ">=22" }` to `package.json`
- Node 20 reached EOL in April 2026; Node 22 is Active LTS until April 2027
- Also update `NODE_VERSION` env var in the Cloudflare Pages dashboard from `20` to `22`

**Facebook OG image tags**
- Adds `og:image:secure_url` (Facebook expects this alongside `og:image` for HTTPS-hosted images)
- Adds `og:image:type` (`image/png` — makes MIME type explicit rather than inferred)
- Adds `og:image:alt` (accessibility + required by some validators)
- Resolves the Facebook Sharing Debugger warning about inferring the `og:image` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)