### PR TITLE
chore: use lts/* for Node.js version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "npm"
       - run: npm ci
       - run: npm run lint
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "npm"
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
Switches `node-version` from `22` to `lts/*` in both `ci.yml` and `release.yml`. Tracks the active LTS automatically — no manual bump needed when a new LTS ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)