### PR TITLE
fix: run release workflow only after CI passes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
 
 permissions:
@@ -11,6 +13,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Switches the release workflow trigger from `push` to `workflow_run`, so semantic-release only fires once the CI workflow completes successfully on main. If CI fails, no release is attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)