### PR TITLE
fix: align lightswitch button with privacy icon in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -23,7 +23,7 @@ import { Icon } from 'astro-icon/components';
       <a href="/privacy" aria-label="Privacy policy" style="color: var(--text-subtle); line-height: 1;">
         <Icon name="fa6-solid:lock" style="width: 0.8rem; height: 0.8rem;" />
       </a>
-      <abbr id="lightswitch" title="Cast: Light (Evocation)" style="cursor: pointer; text-decoration: none;">
+      <abbr id="lightswitch" title="Cast: Light (Evocation)" style="cursor: pointer; text-decoration: none; display: inline-flex; align-items: center;">
         <button
           onclick="switchTheme()"
           style="background: none; border: none; cursor: pointer; color: var(--text-subtle); padding: 0; line-height: 1;"


### PR DESCRIPTION
The `<abbr>` wrapping the theme toggle was an inline element, causing it to sit slightly off relative to the `<a>` privacy lock icon beside it in the flex row. Adding `display: inline-flex; align-items: center;` makes it behave consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)