### PR TITLE
feat: blog post — Rebuilding devenney.io with Claude and Cloudflare Pages

### DIFF
--- a/docs/writing-a-blog-post.md
+++ b/docs/writing-a-blog-post.md
@@ -1,0 +1,81 @@
+# Writing a blog post
+
+## Creating the file
+
+Add a `.md` file to `src/content/blog/`:
+
+```
+src/content/blog/YYYY-MM-DD-your-slug.md
+```
+
+The URL will be `https://devenney.io/blog/YYYY-MM-DD-your-slug/`.
+
+## Frontmatter
+
+```markdown
+---
+title: "Post Title"
+description: "One sentence. Shown in SEO meta, RSS, and the blog index."
+date: "YYYY-MM-DD"
+---
+```
+
+`author` is optional and defaults to `Brendan Devenney`.
+
+## Syntax-highlighted code
+
+Fenced code blocks are highlighted with Shiki (night-owl theme). Specify a language:
+
+````markdown
+```typescript
+const greeting = 'hello';
+```
+````
+
+Works with TypeScript, Go, YAML, JSON, Bash, and any other Shiki-supported language. For plain terminal output, use `bash` or no language tag.
+
+## Images
+
+Drop images in `public/assets/images/posts/` and reference them in markdown:
+
+```markdown
+![Description of image](/assets/images/posts/your-image.png)
+```
+
+For a captioned image, use a figure block directly in the markdown:
+
+```html
+<figure>
+  <img src="/assets/images/posts/your-image.png" alt="Description" />
+  <figcaption>Caption text.</figcaption>
+</figure>
+```
+
+## Diagrams
+
+ASCII-style diagrams inside a plain code block work well and fit the site aesthetic:
+
+````markdown
+```
+Before: Build → S3 → CloudFront → check DNS
+After:  git push
+```
+````
+
+Mermaid is not currently configured. If you want proper flowcharts, `rehype-mermaid` can be added to `astro.config.mjs`.
+
+## Prose elements
+
+Standard markdown works throughout:
+
+- `##` / `###` — section headings (Geist Mono, accent colour)
+- `**bold**`, `*italic*`
+- `[link text](url)` — accent colour with underline
+- `> blockquote` — left border in accent colour
+- `` `inline code` `` — monospace, subtle background
+- `---` — horizontal rule
+- Bullet and numbered lists
+
+## Publishing
+
+Push to main (or merge a PR). Cloudflare Pages builds and deploys automatically. The post will appear in `/blog/`, `/rss.xml`, and `/sitemap-0.xml` with no extra configuration.

--- a/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
+++ b/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
@@ -18,7 +18,7 @@ The reason I want to write about this is not the AI angle. It is the stack. Each
 
 [Astro](https://astro.build) is a static site framework with a simple idea: build once, serve flat files, no runtime. For a personal site it is the right default. Content collections give you typed and validated blog posts without a CMS. The island architecture means interactive pieces do not pull in JavaScript you do not need.
 
-The content schema for this blog is about as simple as it gets:
+The previous stack was webpack and Handlebars. Getting a blog post onto the page required a build pipeline, a template, and enough manual wiring that I avoided touching it. The content schema for this blog is about as simple as it gets:
 
 ```typescript
 const blog = defineCollection({
@@ -27,12 +27,11 @@ const blog = defineCollection({
     title: z.string(),
     description: z.string().optional(),
     date: z.string(),
-    author: z.string().default('Brendan Devenney'),
   }),
 });
 ```
 
-Migrating from Astro 5 to 6 was about forty minutes of work: move a config file, update a handful of imports. The error messages told me exactly what to fix.
+Write a markdown file, push, done. No templates, no build configuration to maintain.
 
 One category of problem removed: I no longer have to think about the build system.
 

--- a/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
+++ b/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
@@ -54,13 +54,7 @@ Build command:  npm run build
 Output dir:     dist
 ```
 
-Then you push to main.
-
-```
-git push origin main
-```
-
-Done. Cloudflare handles the CDN, SSL, the www redirect, the HTTP upgrade, and pull request preview deployments. None of it needed any further configuration.
+That is the entire configuration. Every pull request gets a preview deployment automatically, so before merging anything I can click a URL and check it looks right. When I merge, CI has already confirmed there are no broken links and accessibility has not regressed. Cloudflare deploys the result. GitHub Actions tags the release. I do nothing else.
 
 I have been running things on AWS for years and I know how to navigate it. But there is a real difference between infrastructure you can use and infrastructure that stays out of your way. One category of problem removed: I no longer have to think about deployment.
 
@@ -115,9 +109,7 @@ One category of problem removed: I no longer ship broken links without noticing.
 
 ---
 
-The full CI pipeline: lint, type check, build, Lighthouse, link check. Every push to main runs the lot. If anything fails, nothing ships.
-
-The result is a site I am happy with, a deployment I do not think about, and quality checks I do not have to remember to run. The whole thing costs nothing.
+The full flow, from writing to live: open a PR, CI runs lint and type check and Lighthouse and Lychee, Cloudflare Pages builds a preview, I check it looks right, I merge. Cloudflare deploys. GitHub Actions tags the release. That is it.
 
 Every step in this stack was chosen because it removed something from my mental overhead. Personal time is finite. I would rather spend mine watching the football.
 

--- a/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
+++ b/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
@@ -47,12 +47,11 @@ Build → S3 sync → CloudFront invalidate → check DNS → hope
 
 Three AWS services, IAM policies that needed to be exactly right, and a mental overhead that meant I avoided shipping unless I had a good reason.
 
-[Cloudflare Pages](https://pages.cloudflare.com) is configured with four fields:
+[Cloudflare Pages](https://pages.cloudflare.com) is configured with two fields:
 
 ```
 Build command:  npm run build
 Output dir:     dist
-NODE_VERSION:   22
 ```
 
 Then you push to main.

--- a/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
+++ b/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
@@ -111,6 +111,6 @@ One category of problem removed: I no longer ship broken links without noticing.
 
 The full flow, from writing to live: open a PR, CI runs lint and type check and Lighthouse and Lychee, Cloudflare Pages builds a preview, I check it looks right, I merge. Cloudflare deploys. GitHub Actions tags the release. That is it.
 
-Every step in this stack was chosen because it removed something from my mental overhead. Personal time is finite. I would rather spend mine watching the football.
+Every step in this stack was chosen because it removed something from my mental overhead. Personal time is finite. I would rather spend mine watching Scotland win the world cup.
 
 The source is [on GitHub](https://github.com/devenney/devenney.io).

--- a/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
+++ b/src/content/blog/2026-06-14-migrating-to-astro-and-cloudflare-pages.md
@@ -1,0 +1,126 @@
+---
+title: "Rebuilding devenney.io with Claude and Cloudflare Pages"
+description: "Every few years I rebuild this site. This one happened over a weekend, between World Cup matches. Here is what the stack looks like now, and what each piece taught me about protecting personal time."
+date: "2026-06-14"
+---
+
+Every few years, I rebuild this site.
+
+This one happened over a weekend, between World Cup matches.
+
+The pattern is consistent: new technology arrives, I wait until the guilt about the old stack becomes unbearable, and I redo the whole thing. The previous site was webpack and Handlebars, which tells you roughly how long it had been sitting there. I have been busy. I also jumped straight past whatever the intermediate era is supposed to be (pick your flavour of React framework) and landed directly in the Claude and Astro 6 era. I did manage to keep Tailwind, as I love that framework.
+
+The honest context: most of this rewrite was done by [Claude Code](https://claude.ai/code). The workflow was: write a spec, hand it to Claude, review the output, iterate. I contributed the judgment; Claude contributed the typing. That is a workflow you can fit between matches.
+
+The reason I want to write about this is not the AI angle. It is the stack. Each technology I picked had the same criterion: does it remove a category of problem from my personal time, or add one? Every step closer to that answer being "remove" is a step closer to being able to focus on the things that are actually worth my time.
+
+## Astro
+
+[Astro](https://astro.build) is a static site framework with a simple idea: build once, serve flat files, no runtime. For a personal site it is the right default. Content collections give you typed and validated blog posts without a CMS. The island architecture means interactive pieces do not pull in JavaScript you do not need.
+
+The content schema for this blog is about as simple as it gets:
+
+```typescript
+const blog = defineCollection({
+  loader: glob({ pattern: '**/[^_]*.md', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    date: z.string(),
+    author: z.string().default('Brendan Devenney'),
+  }),
+});
+```
+
+Migrating from Astro 5 to 6 was about forty minutes of work: move a config file, update a handful of imports. The error messages told me exactly what to fix.
+
+One category of problem removed: I no longer have to think about the build system.
+
+## Cloudflare Pages
+
+This is the part worth writing about.
+
+Here is what deploying used to look like:
+
+```
+Build → S3 sync → CloudFront invalidate → check DNS → hope
+```
+
+Three AWS services, IAM policies that needed to be exactly right, and a mental overhead that meant I avoided shipping unless I had a good reason.
+
+[Cloudflare Pages](https://pages.cloudflare.com) is configured with four fields:
+
+```
+Build command:  npm run build
+Output dir:     dist
+NODE_VERSION:   22
+```
+
+Then you push to main.
+
+```
+git push origin main
+```
+
+Done. Cloudflare handles the CDN, SSL, the www redirect, the HTTP upgrade, and pull request preview deployments. None of it needed any further configuration.
+
+I have been running things on AWS for years and I know how to navigate it. But there is a real difference between infrastructure you can use and infrastructure that stays out of your way. One category of problem removed: I no longer have to think about deployment.
+
+It is also free.
+
+## Lighthouse CI
+
+[Lighthouse](https://github.com/GoogleChrome/lighthouse) is Google's tool for auditing accessibility, SEO, and performance. Running it in CI means any regression fails the build before it ships.
+
+The configuration lives in `.lighthouserc.json`:
+
+```json
+{
+  "ci": {
+    "collect": { "staticDistDir": "./dist" },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:seo":           ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": { "target": "temporary-public-storage" }
+  }
+}
+```
+
+The key detail for a statically built site: use `staticDistDir` rather than pointing Lighthouse at a live URL. Astro builds flat HTML files you can audit locally without a server. The `upload` block is optional but gives you a shareable report URL for every CI run at no cost.
+
+It caught several accessibility issues I would not have noticed manually. One category of problem removed: quality regressions that used to slip through now do not.
+
+## Lychee
+
+[Lychee](https://lychee.cli.rs) checks every link in the built site. It is one step in the CI workflow:
+
+```yaml
+- name: Serve dist for link check
+  run: npx --yes serve dist -l 4321 &
+
+- name: Wait for server
+  run: npx --yes wait-on http://localhost:4321 --timeout 15000
+
+- name: Check links
+  uses: lycheeverse/lychee-action@v2
+  with:
+    args: --verbose --no-progress --exclude 'linkedin\.com' http://localhost:4321/
+    fail: true
+```
+
+The non-obvious thing: Lychee cannot resolve root-relative links (like `/blog/` or `/rss.xml`) from static HTML files directly. The fix is to serve `dist/` on a local port first and point Lychee at the running server. Two extra steps, but it means broken links fail the build.
+
+One category of problem removed: I no longer ship broken links without noticing.
+
+---
+
+The full CI pipeline: lint, type check, build, Lighthouse, link check. Every push to main runs the lot. If anything fails, nothing ships.
+
+The result is a site I am happy with, a deployment I do not think about, and quality checks I do not have to remember to run. The whole thing costs nothing.
+
+Every step in this stack was chosen because it removed something from my mental overhead. Personal time is finite. I would rather spend mine watching the football.
+
+The source is [on GitHub](https://github.com/devenney/devenney.io).

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -239,6 +239,23 @@ article.prose hr {
   border-top: 1px solid var(--border);
   margin: 2rem 0;
 }
+article.prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  margin: 1.5rem 0;
+}
+article.prose figure {
+  margin: 1.5rem 0;
+}
+article.prose figcaption {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-subtle);
+  margin-top: 0.5rem;
+  text-align: center;
+}
 
 iframe.fullscreen {
   position: fixed;


### PR DESCRIPTION
New post covering the Astro 6 + Cloudflare Pages weekend rebuild.

Also adds `article.prose img`, `figure`, and `figcaption` styles to `global.css` — the site can now render screenshots with captions in blog posts.

**Diagram approach used:** ASCII-style code block for the before/after deployment comparison. Fits the Terminal Noir aesthetic and requires no new dependencies. Mermaid support can be added separately if richer diagrams are wanted in future.

**Screenshots:** none in this post, but the image styles are ready. Drop images in `public/assets/images/posts/` and reference them as `![alt](/assets/images/posts/filename.png)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)