### PR TITLE
chore: add additional socials to JSON-LD

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,6 +25,7 @@ const ogImage = 'https://devenney.io/assets/images/logo_sm.png';
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="canonical" href={canonical} />
+    <link rel="me" href="https://mastodon.social/@brendandevenney" />
 
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -76,7 +77,10 @@ const ogImage = 'https://devenney.io/assets/images/logo_sm.png';
         "knowsAbout": ["Go", "Cloud", "Security", "Software Engineering", "Payments"],
         "sameAs": [
           "https://github.com/devenney",
-          "https://uk.linkedin.com/in/brendan-devenney"
+          "https://uk.linkedin.com/in/brendan-devenney",
+          "https://mastodon.social/@brendandevenney",
+          "https://bsky.app/profile/brendandevenney.bsky.social",
+          "https://dev.to/brendandevenney"
         ]
       }
     </script>


### PR DESCRIPTION
Add `sameAs` for dev.to, Bluesky, Mastodon.

Add ownership proof for Mastodon.