### PR TITLE
fix: stop company separator dot being underlined as link

### DIFF
--- a/src/components/WorkEntry.astro
+++ b/src/components/WorkEntry.astro
@@ -18,6 +18,7 @@ const { years, title, company, companyUrl, description, muted = false } = Astro.
     <span style={`font-size: ${muted ? '0.75rem' : '0.78rem'}; color: ${muted ? 'var(--text-muted)' : 'var(--text-3)'};`}>
       {title}
     </span>
+    <span style="font-size: 0.75rem; color: var(--text-subtle); margin-left: 0.3rem;">&middot;</span>
     {companyUrl ? (
       <a
         href={companyUrl}
@@ -25,11 +26,11 @@ const { years, title, company, companyUrl, description, muted = false } = Astro.
         rel="noopener noreferrer"
         style={`font-size: ${muted ? '0.75rem' : '0.75rem'}; color: var(--text-subtle); margin-left: 0.3rem; text-decoration: underline; text-underline-offset: 2px;`}
       >
-        &middot; {company}
+        {company}
       </a>
     ) : (
       <span style={`font-size: ${muted ? '0.75rem' : '0.75rem'}; color: var(--text-subtle); margin-left: 0.3rem;`}>
-        &middot; {company}
+        {company}
       </span>
     )}
     {description && (


### PR DESCRIPTION
## Problem

On work entries, the `·` separator before company names sat **inside** the `<a>` tag in `WorkEntry.astro`. The anchor's `text-decoration: underline` therefore underlined the dot as well as the company name, which looked broken — especially on mobile.

## Fix

Move the `&middot;` separator into its own `<span>` outside the anchor, so only the company name is rendered as the underlined link. Spacing is preserved.

## Verification

- `npm run build` passes
- Inspected built HTML: dot now renders as `<span>…&middot;</span>` followed by a separate `<a>`, so the underline no longer covers the dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)