### PR TITLE
Add "One Year" Approov anniversary blog post

### DIFF
--- a/src/content/blog/2026-07-01-one-year.md
+++ b/src/content/blog/2026-07-01-one-year.md
@@ -1,0 +1,65 @@
+---
+title: "One Year"
+description: "Brendan Devenney, a software engineer in Edinburgh, marks one year at mobile and API security company Approov, and asks which parts of the craft still matter now that the agentic era has arrived."
+date: "2026-07-01"
+---
+
+A year ago today, I started at Approov.
+
+A hundred days in, I wrote about the transition: leaving management, the refreshing day-to-day feedback loop, the strange experience of relearning a craft I thought I'd lost. I stand by most of it. But a hundred days is enough to notice a change; it takes a year to understand it.
+
+So here is what a year taught me that a hundred days couldn't.
+
+## The rust that mattered
+
+At a hundred days I called myself rusty. I was. I reached for patterns that no longer fit and looked up syntax I once knew by heart.
+
+I expected that to be the hard part. It wasn't.
+
+The rust came off faster than I feared, and somewhere along the way I realised I'd been worried about the wrong thing entirely. The agentic era arrived in earnest this year, and it quietly rewrote the job description. The premium skill is no longer how fast you can produce code from memory. It's whether you can write a precise specification and make a strong architectural decision, then judge honestly whether what comes back is any good.
+
+Those are not new skills for me. They are the exact skills that years of reviewing architecture and mentoring engineers had been sharpening the whole time.
+
+The craft I sat down to relearn was not the craft that turned out to matter.
+
+I spent years assuming management had pulled me away from engineering. It hadn't. It had been quietly preparing me for the version of engineering that was coming.
+
+Charity Majors has a name for the shape of this: the engineer/manager pendulum. The idea that a healthy career swings between the two, rather than treating management as a one-way door you walk through once and never come back. I didn't choose when mine swung back. But it swung the right way, and the years spent on the other side weren't lost. They were compounding.
+
+## A secure transaction is a secure transaction
+
+The work itself has been a homecoming of a different kind.
+
+I spent years in payments. Now I work in mobile and API security. On paper those are different worlds, but the longer I sit with them the more they rhyme. Strip away the vocabulary and you find the same problem underneath: a secure transaction is a secure transaction. It has to go fast enough that the user never notices, and securely enough that there is never any danger. Get the balance wrong in either direction and you've failed.
+
+There is one difference, though, and it changes everything.
+
+In bank-to-bank payments you can largely trust both ends of the wire. Both sides are regulated, identified, accountable. In mobile security you can trust nothing. The client is in the hands of someone who may be actively trying to deceive you, running on a device you don't control, talking to an API that has no way of knowing, without help, whether the thing on the other end is your real app or a clever imitation of it.
+
+Trust is the whole game. In payments you mostly start with it. In mobile security you have to earn it, every single request.
+
+That single shift in assumption has been the most interesting thing I've learned all year.
+
+## Pulling in the same direction
+
+For years I sat in a strange middle layer. I didn't fully understand the decisions being made above me, and I couldn't always explain to the people below me why we were doing what we were doing. I translated in both directions and was fluent in neither.
+
+That layer is gone, and it might be the best part of the whole year. I pull in the same direction as the people next to me now. We talk, we decide, we build. When something needs heavier process we add it; otherwise we don't. It is the inversion of the corporate default, and a year in I'm convinced it's the right one. Not because process is bad, but because most of it is inertia wearing a calendar invite.
+
+What surprised me is how well the scale-up instincts I thought I'd left behind have aged. Approov is maturing, adding the enterprise capabilities that bigger customers need, without losing the punch that makes a focused product company worth working for. You can see it in the open in something like the [3.6 release preview](https://approov.io/blog/approov-3-6-release-preview). Knowing how to grow up without slowing down turns out to be a rarer skill than I gave it credit for.
+
+Predictable where it counts; fast everywhere else.
+
+## Full circle
+
+I'd love to end this neatly. I can't, because I'm still figuring it out.
+
+I can say with confidence that this was a good move, for my career and for my happiness. But I'd be lying if I said the ground feels stable. More than half of internet traffic is agentic now. Before long, more than half of the code will be too. I genuinely don't know what that makes an individual contributor in five years. I think about it most when I think about the junior engineers I'm responsible for. What exactly am I preparing them for?
+
+I don't have the answer. But I have found something that feels like the right response to the uncertainty.
+
+This year I became a placement host, mentoring students on their year in industry. That is precisely how I arrived here myself, years ago, when Approov was still CriticalBlue and I was the one who didn't know anything yet. Someone took a chance on a placement student and built him up. Now I get to do the same, and there is a symmetry to that I didn't go looking for and am very grateful to have found.
+
+Maybe that's the answer to the agentic question, or at least the start of one. The tools will keep changing. What we owe the next person coming up behind us doesn't.
+
+If you've made a leap like this, out of management, into something new, or back to something you'd left, I'd love to hear how it landed for you. Reach out.


### PR DESCRIPTION
## Summary

Adds the "One Year" blog post marking one year at Approov. It's the third entry in the milestone-post series (after "1,000 Days" at Form3 and "100 Days" at Approov) and the direct sequel to "100 Days".

Themes:
- The engineer/manager pendulum (Charity Majors) — the redundancy-driven return to IC reframed as the pendulum swinging the right way
- How the agentic era reshaped the IC craft: precise specs and architectural judgment over recalling syntax
- "A secure transaction is a secure transaction" — the payments ↔ mobile-security trust contrast (carries the security/Edinburgh disambiguation signals)
- Pulling in the same direction as the team; scale-up habits aging well as Approov matures
- Full-circle close: hosting placement students, exactly how the author joined when Approov was CriticalBlue

## Details
- New file: `src/content/blog/2026-07-01-one-year.md`, dated `2026-07-01` (the anniversary)
- `description` frontmatter carries entity/AEO disambiguation signals (software engineer, Edinburgh, Approov, mobile/API security)
- One contextual outbound link to the public Approov 3.6 release preview; no internal/proprietary detail
- House style: no em-dashes

## Test plan
- [x] `npm run build` passes; post renders at `/blog/2026-07-01-one-year/`
- [x] Post appears in `/rss.xml` (triggers auto-syndication to Bluesky/Mastodon on publish)
- [ ] Visual review of rendered post before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)