### PR TITLE
fix: correct and cite the automated-traffic claim in "One Year"

### DIFF
--- a/src/content/blog/2026-07-01-one-year.md
+++ b/src/content/blog/2026-07-01-one-year.md
@@ -24,7 +24,7 @@ The craft I sat down to relearn was not the craft that turned out to matter.
 
 I spent years assuming management had pulled me away from engineering. It hadn't. It had been quietly preparing me for the version of engineering that was coming.
 
-Charity Majors has a name for the shape of this: the engineer/manager pendulum. The idea that a healthy career swings between the two, rather than treating management as a one-way door you walk through once and never come back. I didn't choose when mine swung back. But it swung the right way, and the years spent on the other side weren't lost. They were compounding.
+Charity Majors has a name for the shape of this: the [engineer/manager pendulum](https://charity.wtf/2017/05/11/the-engineer-manager-pendulum/). The idea that a healthy career swings between the two, rather than treating management as a one-way door you walk through once and never come back. I didn't choose when mine swung back. But it swung the right way, and the years spent on the other side weren't lost. They were compounding.
 
 ## A secure transaction is a secure transaction
 
@@ -54,7 +54,7 @@ Predictable where it counts; fast everywhere else.
 
 I'd love to end this neatly. I can't, because I'm still figuring it out.
 
-I can say with confidence that this was a good move, for my career and for my happiness. But I'd be lying if I said the ground feels stable. More than half of internet traffic is agentic now. Before long, more than half of the code will be too. I genuinely don't know what that makes an individual contributor in five years. I think about it most when I think about the junior engineers I'm responsible for. What exactly am I preparing them for?
+I can say with confidence that this was a good move, for my career and for my happiness. But I'd be lying if I said the ground feels stable. For the first time in a decade, [more than half of all web traffic is now automated rather than human](https://www.imperva.com/blog/2025-imperva-bad-bot-report-how-ai-is-supercharging-the-bot-threat/), and AI is what's driving the surge. Before long, I suspect the same will be true of the code we ship. I genuinely don't know what that makes an individual contributor in five years. I think about it most when I think about the junior engineers I'm responsible for. What exactly am I preparing them for?
 
 I don't have the answer. But I have found something that feels like the right response to the uncertainty.
 


### PR DESCRIPTION
## Summary

Follow-up fix to #164 (already merged). Corrects an inaccurate statistic in the "One Year" post and adds source citations.

- **Corrected claim:** "half of internet traffic is agentic" was inaccurate. The sourced figure is that automated/bot traffic (all bots, not specifically AI agents) surpassed human traffic for the first time in a decade at ~51%, per the 2025 Imperva Bad Bot Report. Reworded accordingly and linked to the source.
- **Softened projection:** the "half of code will be too" line is reframed as clearly-signalled opinion ("I suspect").
- **Attribution:** added a link from the engineer/manager pendulum to Charity Majors' original 2017 post.

## Details
- Single file: `src/content/blog/2026-07-01-one-year.md`
- Two lines changed (see diff); no other content affected

## Test plan
- [x] `npm run build` passes; post renders at `/blog/2026-07-01-one-year/`
- [x] Both source links verified present (imperva.com, charity.wtf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)